### PR TITLE
Adicionado slack da comunidade iOSDevBR

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Badge | Link | Participar
 - | [Angular Buddies](http://angularbuddies.com/) | [Participar](https://pocket1.typeform.com/to/agYVyz)
 - | [Python Brasil](https://pythonbrasil.slack.com) | [Participar](http://slack-pythonbrasil.herokuapp.com/)
 ![Participantes](http://dotnetarchitects.azurewebsites.net/Home/Presence) | [.Net Architects](http://dotnetarchitects.slack.com/) | [Participar](http://dotnetarchitects.azurewebsites.net/)
+![Participantes](http://iosdevbr.herokuapp.com/badge.svg) | iOS Dev BR | [Participar](http://iosdevbr.herokuapp.com/)
 ## Empreendedorismo
 
 Badge | Link | Participar


### PR DESCRIPTION
O iOSDevBR é o maior slack público de desenvolvedores iOS no Brasil. Foi formado a partir do iPhoneDevBR, maior comunidade nacional de desenvolvedores Apple e conta com o apoio das comunidades Cocoaheads e Appsterdam.